### PR TITLE
Fix the bug where scan would fail in TwoTiers() case

### DIFF
--- a/MetalScanApp/ExclusiveScan.swift
+++ b/MetalScanApp/ExclusiveScan.swift
@@ -40,13 +40,7 @@ public class ExclusiveScan {
             else { fatalError("Cannot scan") }
         
         doScan(dataBuffer, count)
-        
-        let bound = dataBuffer.contents().bindMemory(to: Int32.self, capacity: count)
-        var result = [Int32](repeating: 0, count: count)
-        for i in 0..<count {
-            result[i] = bound[i]
-        }
-        return result
+        return toArray(dataBuffer, count)
     }
     
     private func doScan(_ dataBuffer: MTLBuffer, _ count: Int) {
@@ -59,9 +53,8 @@ public class ExclusiveScan {
         let threadgroupMtlSz = MTLSize(width: threadgroupsCount, height: 1, depth: 1)
         var constants = Constants(count: uint(count))
         guard let blockSumBuffer = device.makeBuffer(length: threadgroupsCount * MemoryLayout<Int32>.stride,
-                                                     options: []) else {
-                                                        fatalError("Cannot create blockSumBuffer")
-        }
+                                                     options: [])
+            else { fatalError("Cannot create blockSumBuffer") }
         
         scanEncoder.setComputePipelineState(scanPipelineState)
         scanEncoder.setBuffer(dataBuffer, offset: 0, index: 0)
@@ -91,5 +84,14 @@ public class ExclusiveScan {
         
         addBlockSumCmdBuffer.commit()
         addBlockSumCmdBuffer.waitUntilCompleted()
+    }
+    
+    private func toArray(_ buffer: MTLBuffer, _ count: Int) -> [Int32] {
+        let bound = buffer.contents().bindMemory(to: Int32.self, capacity: count)
+        var result = [Int32](repeating: 0, count: count)
+        for i in 0..<count {
+            result[i] = bound[i]
+        }
+        return result
     }
 }

--- a/MetalScanApp/Scan.metal
+++ b/MetalScanApp/Scan.metal
@@ -50,6 +50,10 @@ kernel void exclusive_scan(device int32_t* data [[buffer(0)]],
         }
         stride <<= 1;
     }
+    
+    // Without this barrier, setting tg_mem[-1] to 0 may not be properly
+    // propagated across the entire threadgroup.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
     // clear the last element
     if (tgid == 0) {
         tg_mem[kThreadgroupSize - 1] = 0;
@@ -68,6 +72,7 @@ kernel void exclusive_scan(device int32_t* data [[buffer(0)]],
         }
         stride = half_stride;
     }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
     if (tid < count) {
          data[tid] = tg_mem[tgid];
     }


### PR DESCRIPTION
Bug:

After running up-stream, we didn't now use proper synchronization `threadgroup_barrier()` when resetting the last element to zero. This caused the data in the `threadgroup` memory not being propagated.